### PR TITLE
add .cabal as per stack recommendation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ cabal-dev
 .hsenv
 .cabal-sandbox/
 cabal.sandbox.config
-*.cabal
 
 # Emacs
 

--- a/quickcheck-arbitrary-template.cabal
+++ b/quickcheck-arbitrary-template.cabal
@@ -1,0 +1,67 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           quickcheck-arbitrary-template
+version:        0.2.0.0
+synopsis:       Generate QuickCheck Gen for Sum Types
+description:    Building Sum Type arbitrary instance is kind of a pain. This tool helps automate the process.
+category:       Testing
+homepage:       https://github.com/plow-technologies/quickcheck-arbitrary-template#readme
+bug-reports:    https://github.com/plow-technologies/quickcheck-arbitrary-template/issues
+author:         Scott Murphy <scottmurphy09@gmail.com>
+maintainer:     Scott Murphy <scottmurphy09@gmail.com>
+copyright:      2016-2018 Plow Technologies
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/plow-technologies/quickcheck-arbitrary-template
+
+library
+  exposed-modules:
+      Test.QuickCheck.TH.Generators
+      Test.QuickCheck.TH.Generators.Internal
+      Test.QuickCheck.TH.Generators.Internal.BuildArbitrary
+  other-modules:
+      Paths_quickcheck_arbitrary_template
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      QuickCheck
+    , base >=4 && <5
+    , safe
+    , template-haskell >=2.11 && <2.16
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Test.QuickCheck.TH.Generators
+      Test.QuickCheck.TH.Generators.Internal
+      Test.QuickCheck.TH.Generators.Internal.BuildArbitrary
+      Test.QuickCheck.TH.GeneratorsSpec
+      Paths_quickcheck_arbitrary_template
+  hs-source-dirs:
+      src
+      test
+  ghc-options: -Wall
+  build-depends:
+      QuickCheck
+    , base >=4 && <5
+    , safe
+    , tasty
+    , tasty-golden
+    , tasty-hunit
+    , tasty-quickcheck
+    , template-haskell >=2.11 && <2.16
+  default-language: Haskell2010


### PR DESCRIPTION
Recommended in
https://github.com/commercialhaskell/stack/issues/5210

Now I see
```
DEPRECATED: The package at Repo from https://github.com/bitemyapp/quickcheck-arbitrary-template.git, commit 783f9b78ce0170479985c9c60e1b56af131be53d does not include a cabal file.
Instead, it includes an hpack package.yaml file for generating a cabal file.
This usage is deprecated; please see https://github.com/commercialhaskell/stack/issues/5210.
Support for this workflow will be removed in the future.

```